### PR TITLE
Enable Parser Functions

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -171,6 +171,7 @@ wfLoadSkin( 'Vector' );
 wfLoadExtension( 'CodeEditor' );
 wfLoadExtension( 'WikiEditor' );
 
+wfLoadExtension( 'ParserFunctions' );
 wfLoadExtension( 'SandstormAuth' );
 
 


### PR DESCRIPTION
So I am trying to migrate a wiki over which uses infobox templates. My understanding is the #if functions are throwing things off. ParserFunctions is included in MediaWiki by default, but not loaded without this option.

Details about this extension are here: https://www.mediawiki.org/wiki/Help:Extension:ParserFunctions